### PR TITLE
Fixed crash on form submission when not logged in

### DIFF
--- a/front-end/src/pages/FormComponent/FormComponent.tsx
+++ b/front-end/src/pages/FormComponent/FormComponent.tsx
@@ -23,8 +23,8 @@ export default function FormComponent({closeModal, locationCoordinates}) {
     lon: number;
   } | null>(null);
 
-  var { userName } = useAuth().user;
-  if (!userName) userName = "";
+  if (userName) var { userName } = useAuth().user;
+  else var userName = "";
 
   //populate the coordinates with information from the map page
   useEffect(() => {
@@ -91,6 +91,11 @@ export default function FormComponent({closeModal, locationCoordinates}) {
     }
 
     try {
+      if (!userName) {
+        setError("Please log in to submit a report");
+        return;
+      }
+
       //create an easy obj to post to our database
       const formData = new FormData();
       formData.append("image", file);


### PR DESCRIPTION
The page would crash when the user was not logged in and clicked on the pet map. This has now been fixed.

Added to handleSubmit() in FormComponent:
`
if (userName) var { userName } = useAuth().user;
else var userName = "";
...
if (!userName) {
        setError("Please log in to submit a report");
        return;
}`

